### PR TITLE
Reads file when uploading to S3

### DIFF
--- a/canotic/apis/data.py
+++ b/canotic/apis/data.py
@@ -96,7 +96,7 @@ class DataApiMixin(ABC):
                                query_params={'path': path, 'description': description, 'mimeType': mimeType,
                                              'uploadUrl': True}, required_api_key=True)
         try:
-            resp = requests.put(dataset.pop('uploadUrl'), data=file)
+            resp = requests.put(dataset.pop('uploadUrl'), data=file.read())
             if resp.status_code == 200 or resp.status_code == 201:
                 return dataset
             else:


### PR DESCRIPTION
Given the fact that python requests library uses chunked transfer encoding
for large files and s3 doesn't support this the file needs to be read
before send to s3