### PR TITLE
Update canotic.com to https://canotic.com/

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     version=VERSION,
     description="Canotic API",
     author_email="",
-    url="canotic.com",
+    url="https://canotic.com/",
     keywords=["Canotic API"],
     install_requires=REQUIRES,
     packages=find_packages(),


### PR DESCRIPTION
'canotic.com' caused an 400 error when uploading the code on pypi.